### PR TITLE
Fix di compile issue

### DIFF
--- a/app/code/Ometria/AbandonedCarts/Block/Redirect.php
+++ b/app/code/Ometria/AbandonedCarts/Block/Redirect.php
@@ -7,16 +7,14 @@ class Redirect extends \Magento\Framework\View\Element\Template
     protected $salesModelQuote;
     protected $scopeConfig;
     public function __construct(
-        \Magento\Framework\View\Element\Template\Context $context, 
-        \Magento\Framework\App\RequestInterface $request,  
-        \Magento\Quote\Model\Quote $salesModelQuote,   
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,           
+        \Magento\Framework\View\Element\Template\Context $context,
+        \Magento\Quote\Model\Quote $salesModelQuote,         
         array $data = []
     )
     {    
-        $this->request = $request;
+        $this->request = $context->getRequest();
+        $this->scopeConfig = $context->getScopeConfig();
         $this->salesModelQuote = $salesModelQuote;
-        $this->scopeConfig = $scopeConfig;
         return parent::__construct($context, $data);
     }
     


### PR DESCRIPTION
Di compile failed with this without this change:
```
Compilation was started.
Interception cache generation... 6/7 [========================>---]  85% 5 mins 374.0 MiBErrors during compilation:
	Ometria\AbandonedCarts\Block\Redirect
		Incorrect dependency in class Ometria\AbandonedCarts\Block\Redirect in /home/scrutinizer/build/vendor/ometria/magento2/app/code/Ometria/AbandonedCarts/Block/Redirect.php
\Magento\Framework\App\RequestInterface already exists in context object
\Magento\Framework\App\Config\ScopeConfigInterface already exists in context object
Total Errors Count: 1
```