### PR TITLE
Bug Fix: Catch exceptions in Helper/Ping.php

### DIFF
--- a/app/code/Ometria/Core/Helper/Ping.php
+++ b/app/code/Ometria/Core/Helper/Ping.php
@@ -104,7 +104,7 @@ class Ping extends AbstractHelper
                 $ometriaConfigHelper->log("Ping failed: Error $errorNum - $errorStr", Zend_Log::ERR);
                 return false;
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $ometriaConfigHelper->log($e->getMessage());
             return false;
         }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "ometria/magento2",
     "type": "magento2-module",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "description": "Dev composer package for Ometria Extension",
     "authors": [
         {


### PR DESCRIPTION
Exceptions are not caught in the Ping helper because the catch clause only catches instances of `Ometria\Core\Helper\Exception` due to a missing `\`