### PR TITLE
Release/2.2.3

### DIFF
--- a/app/code/Ometria/AbandonedCarts/etc/module.xml
+++ b/app/code/Ometria/AbandonedCarts/etc/module.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Ometria_AbandonedCarts" setup_version="2.2.2"/>
+    <module name="Ometria_AbandonedCarts" setup_version="2.2.3"/>
 </config>

--- a/app/code/Ometria/Api/Controller/V2/Products.php
+++ b/app/code/Ometria/Api/Controller/V2/Products.php
@@ -624,7 +624,7 @@ class Products extends Action
     private function getStoreDefaultCurrency($storeId)
     {
         if (!isset($this->storeCurrencies[$storeId])) {
-            $stores = $this->storeManager->getStores();
+            $stores = $this->storeManager->getStores(true);
 
             foreach ($stores as $store) {
                 $this->storeCurrencies[$store->getId()] = $store->getDefaultCurrency()->getCode();

--- a/app/code/Ometria/Api/etc/module.xml
+++ b/app/code/Ometria/Api/etc/module.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Ometria_Api" setup_version="2.2.2"/>
+    <module name="Ometria_Api" setup_version="2.2.3"/>
 </config>

--- a/app/code/Ometria/Core/etc/module.xml
+++ b/app/code/Ometria/Core/etc/module.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Ometria_Core" setup_version="2.2.2"/>
+    <module name="Ometria_Core" setup_version="2.2.3"/>
 </config>

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "ometria/magento2",
     "type": "magento2-module",
-    "version": "2.2.2",
+    "version": "2.2.3",
     "description": "Dev composer package for Ometria Extension",
     "authors": [
         {


### PR DESCRIPTION
M2-45 - Patch release to include admin store (ID == 0) when retrieving currencies, incase a product is assigned to the admin store.