### PR TITLE
Correct namespace in ping error logging class.

### DIFF
--- a/app/code/Ometria/AbandonedCarts/etc/module.xml
+++ b/app/code/Ometria/AbandonedCarts/etc/module.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Ometria_AbandonedCarts" setup_version="2.3.0"/>
+    <module name="Ometria_AbandonedCarts" setup_version="2.3.1"/>
 </config>

--- a/app/code/Ometria/Api/etc/module.xml
+++ b/app/code/Ometria/Api/etc/module.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Ometria_Api" setup_version="2.3.0"/>
+    <module name="Ometria_Api" setup_version="2.3.1"/>
 </config>

--- a/app/code/Ometria/Core/Helper/Ping.php
+++ b/app/code/Ometria/Core/Helper/Ping.php
@@ -101,7 +101,7 @@ class Ping extends AbstractHelper
 
                 fclose($fp);
             } else {
-                $ometriaConfigHelper->log("Ping failed: Error $errorNum - $errorStr", Zend_Log::ERR);
+                $ometriaConfigHelper->log("Ping failed: Error $errorNum - $errorStr", \Zend_Log::ERR);
                 return false;
             }
         } catch (\Exception $e) {

--- a/app/code/Ometria/Core/etc/module.xml
+++ b/app/code/Ometria/Core/etc/module.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Ometria_Core" setup_version="2.3.0"/>
+    <module name="Ometria_Core" setup_version="2.3.1"/>
 </config>

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "ometria/magento2",
     "type": "magento2-module",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "description": "Dev composer package for Ometria Extension",
     "authors": [
         {


### PR DESCRIPTION
This addresses an issue whereby a failed ping is unable to record a log entry due to incorrect namespacing of the Zend_Log class.